### PR TITLE
docs: add info that more closely matches real usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,33 @@ Add the following to your `pipeline.yml`:
 
 ```yml
 steps:
-  - command: ls
+  - label: ":docker: [${STEP_ENVIRONMENT}/${FARM}] Tag deployed image"
+    agents:
+      queue: $BUILD_AGENT
+    env:
+      FARM: $FARM
+      STEP_ENVIRONMENT: $STEP_ENVIRONMENT
     plugins:
+      - cultureamp/aws-assume-role:
+          role: $BUILD_ROLE
       - cultureamp/deploy-tag#v1.0.0:
           image-ref: "full-image-name-and-tag"
 ```
 
 ## Configuration
 
+Important: this plugin assumes that it has access to ECR for pulling and pushing
+images.
+
+`STEP_ENVIRONMENT` is required to be set in the environment and will be used
+when generating the tag for the image. The `FARM` variable is optional and will
+also be used if available.
+
 ### `image-ref` (Required, string)
 
 The full name of the image to tag, including the registry, repository and tag.
+
+Example: `"${ECR_REPO}:release-${BUILDKITE_BUILD_NUMBER}"`.
 
 ## Developing
 


### PR DESCRIPTION
To start with I just wanted to note that `STEP_ENVIRONMENT` was a required ENV variable, but thought it made sense to update the example adding a bit more stuff